### PR TITLE
Rework scene viewer code in a more fail-safe manner

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -108,14 +108,14 @@ class RamsesExportOperator(bpy.types.Operator):
         for exportable_scene in exporter.get_exportable_scenes():
 
             exportable_scene.set_output_dir(self.directory)
-            inspector = RamsesInspector(exportable_scene)
-            inspector.load_viewer(self.platform)
+            inspector = RamsesInspector(exportable_scene, addon_dir=utils.get_addon_path())
 
             if not exportable_scene.is_valid():
                 validation_report = exportable_scene.get_validation_report()
                 raise RuntimeError(validation_report)
 
             exportable_scene.save()
+            inspector.load_viewer(platform=self.platform)
 
         return {'FINISHED'}
 

--- a/__init__.py
+++ b/__init__.py
@@ -89,7 +89,10 @@ class RamsesExportOperator(bpy.types.Operator):
     platform: bpy.props.EnumProperty(name='Platform',
                                      items=[('x11-egl-es-3-0', 'x11-egl-es-3-0', 'x11-egl-es-3-0'), # (identifier, name, description)
                                             ('wayland-ivi-egl-es-3-0', 'wayland-ivi-egl-es-3-0', 'wayland-ivi-egl-es-3-0'),
-                                            ('wayland-shell-egl-es-3-0', 'wayland-shell-egl-es-3-0', 'wayland-shell-egl-es-3-0')],
+                                            ('wayland-shell-egl-es-3-0', 'wayland-shell-egl-es-3-0', 'wayland-shell-egl-es-3-0'),
+                                            ('windows-wgl-4-2-core', 'windows-wgl-4-2-core', 'windows-wgl-4-2-core'),
+                                            ('windows-wgl-4-5', 'windows-wgl-4-5', 'windows-wgl-4-5'),
+                                            ('windows-wgl-es-3-0', 'windows-wgl-es-3-0', 'windows-wgl-es-3-0')],
                                      description='Platform to use for previews')
 
     def invoke(self, context, event):

--- a/__init__.py
+++ b/__init__.py
@@ -48,6 +48,7 @@ import bpy # NOTE: the bpy import must come below the module reload code
 import pathlib
 import os
 from ramses_export import debug_utils
+from ramses_export import utils
 from ramses_export.ramses_inspector import RamsesInspector
 from ramses_export.exporter import RamsesBlenderExporter
 from bpy_extras.io_utils import ExportHelper

--- a/test/run_all_tests.py
+++ b/test/run_all_tests.py
@@ -90,7 +90,8 @@ def main():
                 'script'        : os.path.join(current_path, 'run_unit_tests.py'),
                 'test_scene'    : os.path.join(current_path, 'test_scenes/cube.blend'),
                 'expected_image': '',
-                'expected_output_files': 1, # The debug log will be generated
+                # NOTE: need to save a scene to see it in the viewer
+                'expected_output_files': 3, # debug.txt, Scene.ramses, Scene.ramres.
             },
         'export_cube' :
             {

--- a/test/test_RamsesBlenderExporter.py
+++ b/test/test_RamsesBlenderExporter.py
@@ -49,10 +49,13 @@ class TestRamsesBlenderExporter(ExporterTestBase, unittest.TestCase):
         exporter.build_from_extracted_representations()
 
         for exportable_scene in exporter.get_exportable_scenes():
-            inspector = ramses_export.ramses_inspector.RamsesInspector(exportable_scene)
-            os.chdir(self.addon_path)
+            exportable_scene.set_output_dir(self.working_dir)
+            exportable_scene.save() # Can't see what we do not save
+            inspector = ramses_export.ramses_inspector.RamsesInspector(exportable_scene, addon_dir=self.addon_path)
             inspector.load_viewer(self.platform)
 
             if not exportable_scene.is_valid():
                 validation_report = exportable_scene.get_validation_report()
                 raise RuntimeError(validation_report)
+
+            inspector.close_viewer()

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,22 @@
+#  -------------------------------------------------------------------------
+#  Copyright (C) 2019 Daniel Werner Lima Souza de Almeida
+#                     dwlsalmeida at gmail dot com
+#  -------------------------------------------------------------------------
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#  -------------------------------------------------------------------------
+
+import os
+from . import debug_utils
+log = debug_utils.get_debug_logger()
+
+def get_addon_path():
+    script_file = os.path.realpath(__file__)
+    directory = os.path.dirname(script_file)
+    return directory
+
+class CustomParameters():
+    """Extra parameters we might set that are not a part of the Blender scene itself"""
+    def __init__(self):
+        self.shader_dir = ''


### PR DESCRIPTION
Previously the viewer would not open at times due to wrong path handling. This is now reworked, with plenty of asserts and nice error messages so mistakes can be spot quickly. A test on Windows would be nice.