### PR TITLE
ExportableScene: Replace blender scene by SceneRepresentation

### DIFF
--- a/exportable_scene.py
+++ b/exportable_scene.py
@@ -16,10 +16,10 @@ class ExportableScene():
     def __init__(self,
                  ramses,
                  ramses_scene,
-                 blender_scene):
+                 blender_scene_representation):
         self.ramses = ramses
-        self.ramses_scene = ramses_scene
-        self.blender_scene = blender_scene
+        self._ramses_scene = ramses_scene
+        self._blender_scene_representation = blender_scene_representation
 
         # Paths are set at a later stage
         self.output_path = None
@@ -27,6 +27,14 @@ class ExportableScene():
         self.ir_groups = []
         self.groups = {}
         self.passes = {}
+
+    @property
+    def ramses_scene(self):
+        return self._ramses_scene
+
+    @property
+    def blender_scene(self):
+        return self._blender_scene_representation.scene
 
     def save(self):
         """Persists the RAMSES scene."""

--- a/exporter.py
+++ b/exporter.py
@@ -84,7 +84,7 @@ class RamsesBlenderExporter():
 
         exportable_scene = ExportableScene(self.ramses,
                                            ramses_scene,
-                                           scene_representation.scene)
+                                           scene_representation)
         exportable_scene.groups = self._build_ramses_render_groups(ramses_scene, ir_groups)
         exportable_scene.passes = self._build_ramses_render_passes(ramses_scene, ir_root)
         exportable_scene.ir_groups = ir_groups


### PR DESCRIPTION
This class contains the blender scene and even more data. Given this
change it becomes possible to access more data in tests.

Signed-off-by: Daniel W. S. Almeida <dwlsalmeida@gmail.com>