### PR TITLE
Baking

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -87,7 +87,7 @@ class Mesh_ListItem(bpy.types.PropertyGroup):
 
     bake_subpanel_is_expanded: bpy.props.BoolProperty(name='Bake settings', default=True)
 
-    bake_subpanel_enable: bpy.props.BoolProperty(name='Enable baking for this node', default=True)
+    bake_subpanel_enable: bpy.props.BoolProperty(name='Enable baking for this node', default=False)
     bake_subpanel_bake_dir: bpy.props.StringProperty(name='Baking output directory', default='')
     bake_subpanel_bake_width: bpy.props.IntProperty(name='Bake width', default=1024, min=1)
     bake_subpanel_bake_height: bpy.props.IntProperty(name='Bake height', default=1024, min=1)

--- a/__init__.py
+++ b/__init__.py
@@ -191,6 +191,16 @@ class RamsesExportOperator(bpy.types.Operator):
                 custom_params.shader_dir = list_item.mesh_GLSL_dir
                 custom_params.render_technique = list_item.mesh_render_technique
 
+            if list_item.bake_subpanel_enable:
+                custom_params.material_bake.enabled = True
+                custom_params.material_bake.bake_width = list_item.bake_subpanel_bake_width
+                custom_params.material_bake.bake_height = list_item.bake_subpanel_bake_height
+                custom_params.material_bake.auto_unwrap_if_needed = list_item.bake_subpanel_auto_unwrap_if_needed
+                if list_item.bake_subpanel_bake_dir:
+                    custom_params.material_bake.bake_dir = list_item.bake_subpanel_bake_dir
+                else:
+                    custom_params.material_bake.bake_dir = self.directory
+
             ret[list_item.name] = custom_params
         return ret
 

--- a/__init__.py
+++ b/__init__.py
@@ -85,6 +85,26 @@ class Mesh_ListItem(bpy.types.PropertyGroup):
                                                     description='A technique describing the effect used to render the geometry.',
                                                     default='')
 
+    bake_subpanel_is_expanded: bpy.props.BoolProperty(name='Bake settings', default=True)
+
+    bake_subpanel_enable: bpy.props.BoolProperty(name='Enable baking for this node', default=True)
+    bake_subpanel_bake_dir: bpy.props.StringProperty(name='Baking output directory', default='')
+    bake_subpanel_bake_width: bpy.props.IntProperty(name='Bake width', default=1024, min=1)
+    bake_subpanel_bake_height: bpy.props.IntProperty(name='Bake height', default=1024, min=1)
+    bake_subpanel_auto_unwrap_if_needed: bpy.props.BoolProperty(name='Smart UV unwrap if needed', default=True)
+
+
+    mesh_bake_type: bpy.props.EnumProperty(# [(identifier, name, description, icon, number), ...]
+                                           items=[
+                                                  ('COMBINED', 'Combined', "Bake combined (bakes all materials, textures, and lighting except specularity)"),
+                                           ],
+                                           name="Bake type",
+                                           description="Whether to bake Cycles shaders and lightning to image textures",
+                                           default=None,
+                                           options={'ANIMATABLE'},
+                                           update=None,
+                                           get=None,
+                                           set=None)
 
 class MeshUIList(UIList):
     """A list displayed in the GLSL tab."""
@@ -237,6 +257,31 @@ class RamsesExportOperator(bpy.types.Operator):
             row = layout.row()
             row.prop(item, "mesh_render_technique")
 
+            self.draw_bake_submenu(item, layout, scn)
+
+    def draw_bake_submenu(self, obj, layout, scn):
+        # This is how we draw collapsible submenus
+        # The BoolProperty controls the drawing for this
+        row = layout.row()
+
+        row.prop(obj,
+                 "bake_subpanel_is_expanded",
+                 icon="TRIA_DOWN" if obj.bake_subpanel_is_expanded else "TRIA_RIGHT",
+                 icon_only=False, emboss=False) # Set icon_only to True if you only want an arrow
+
+        if obj.bake_subpanel_is_expanded:
+            row = layout.row()
+            row.prop(obj, "bake_subpanel_enable")
+            row = layout.row()
+            row.prop(obj, "mesh_bake_type")
+            row = layout.row()
+            row.prop(obj, "bake_subpanel_bake_width")
+            row = layout.row()
+            row.prop(obj, "bake_subpanel_bake_height")
+            row = layout.row()
+            row.prop(obj, "bake_subpanel_bake_dir")
+            row = layout.row()
+            row.prop(obj, "bake_subpanel_auto_unwrap_if_needed")
     # ------- User Interface --------------------
 
     @classmethod

--- a/baking.py
+++ b/baking.py
@@ -1,0 +1,152 @@
+#  -------------------------------------------------------------------------
+#  Copyright (C) 2019 Daniel Werner Lima Souza de Almeida
+#                     dwlsalmeida at gmail dot com
+#  -------------------------------------------------------------------------
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#  -------------------------------------------------------------------------
+
+import bpy
+import math
+import pathlib
+from . import debug_utils
+from . import intermediary_representation
+from . import utils
+log = debug_utils.get_debug_logger()
+
+
+class MaterialBakeConfig():
+    def __init__(self,
+                 bake_width: int = 1024,
+                 bake_height: int = 1024,
+                 bake_dir: str = '',
+                 bake_type: str = 'COMBINED',
+                 auto_unwrap_if_needed: bool = True,
+                 enabled: bool = False):
+        self.bake_width = bake_width
+        self.bake_height = bake_height
+        self.bake_dir = bake_dir if bake_dir else utils.get_addon_path()
+        self.bake_type = bake_type
+        self.auto_unwrap_if_needed = auto_unwrap_if_needed
+        self.enabled = enabled
+
+        assert self.bake_type in ('COMBINED', 'AO', 'SHADOW', 'NORMAL',
+            'UV', 'ROUGHNESS', 'EMIT', 'ENVIRONMENT', 'DIFFUSE', 'GLOSSY', 'TRANSMISSION',
+            'SUBSURFACE'), f'Unknown bake type {self.bake_type}'
+
+        assert pathlib.Path(self.bake_dir).exists(), f'Bake directory does not exist:{self.bake_dir}'
+
+class MaterialBaker():
+    """Controls baking for a given (mesh) node.
+
+    Cycles shaders and lighting can be baked to image textures. This has a few different purposes, most commonly:
+
+    Baking textures like base color or normal maps for export to game engines.
+    Baking ambient occlusion or procedural textures, as a base for texture painting or further edits.
+    Creating light maps to provide global illumination or speed up rendering in games.
+
+    See https://docs.blender.org/manual/en/latest/render/cycles/baking.html for further info"""
+
+    def __init__(self, bake_config: MaterialBakeConfig = None):
+        self.current_node = None # Points to a MeshNode
+        self.current_layer = None # The layer for the current node
+
+        if bake_config:
+            assert isinstance(bake_config, MaterialBakeConfig)
+            self.config = bake_config
+        else:
+            self.config = MaterialBakeConfig()
+
+        if self.config.bake_type != 'COMBINED':
+            raise NotImplementedError('This exporter only supports Bake COMBINED for now')
+
+    def set_current_node(self, node, bake_config: MaterialBakeConfig = None):
+        assert node
+        self.current_node = node
+        self.current_layer = node.find_view_layer()
+        assert self.current_layer
+
+        if bake_config:
+            self.config = bake_config
+
+        assert pathlib.Path(self.config.bake_dir).exists(), f'Bake directory does not exist:{self.config.bake_dir}'
+
+    def clear_current_node(self):
+        self.current_node = None
+        self.current_layer = None
+        self.config.bake_dir = ''
+
+    def do_node(self, node=None, bake_config: MaterialBakeConfig = None):
+        if node:
+            self.set_current_node(node, bake_config)
+
+        assert self.current_node
+        assert isinstance(self.current_node, intermediary_representation.MeshNode), 'Only meshes are supported for now'
+
+        if self.config.auto_unwrap_if_needed:
+            self._smart_project_if_needed()
+
+        assert self.current_node.is_UV_unwrapped(), "Node should be unwrapped by now"
+
+        textures = self.bake_to_disk()
+
+        self.current_node.textures = textures # RAMSES can load directly from PNG
+
+    def _smart_project_if_needed(self):
+        assert isinstance(self.current_node, intermediary_representation.MeshNode), 'Only meshes are supported for now'
+
+        if not self.current_node.is_UV_unwrapped():
+
+            with utils.this_object_selected(self.current_node.blender_object, make_active=True, view_layer=self.current_layer.view_layer):
+                log.debug(f'Smart UV unwrapping node "{str(self.current_node)}"')
+
+                for face in self.current_node.get_faces():
+                    face.select_set(True)
+
+                uv = self.current_node.create_UV_layer()
+                uv.active = True
+
+                old_mode = None
+                if bpy.context.object.mode != 'EDIT':
+                    old_mode = bpy.context.object.mode
+                    bpy.ops.object.mode_set(mode='EDIT')
+
+                bpy.ops.uv.smart_project(angle_limit=math.radians(66), island_margin = 0.02)
+
+                if old_mode:
+                    bpy.ops.object.mode_set(mode=old_mode)
+
+    def bake_to_disk(self):
+        ret = {}
+
+        with utils.this_object_selected(self.current_node.blender_object, make_active=True, view_layer=self.current_layer.view_layer):
+
+            assert self.current_node.is_UV_unwrapped(), "Node should be unwrapped by now"
+            assert self.config.bake_type in ('COMBINED', 'AO', 'SHADOW', 'NORMAL',
+             'UV', 'ROUGHNESS', 'EMIT', 'ENVIRONMENT', 'DIFFUSE', 'GLOSSY', 'TRANSMISSION',
+             'SUBSURFACE'), f'Unknown bake type {self.config.bake_type}'
+
+            images = self.current_node.create_IMG_nodes_for_baking(width=self.config.bake_width, height=self.config.bake_height)
+
+            for image in images:
+                filepath = str(pathlib.Path(self.config.bake_dir)/image.name/f'{self.config.bake_type}.png')
+                image.filepath = filepath
+                bpy.ops.object.bake(type=self.config.bake_type,
+                                    filepath=filepath,
+                                    width=self.config.bake_width,
+                                    height=self.config.bake_height,
+                                    save_mode='EXTERNAL',
+                                    use_split_materials=False,
+                                    use_automatic_name=False,
+                                    use_clear=True)
+
+                image.save_render(filepath)
+
+                assert pathlib.Path(filepath).exists(), "Baking operation did not produce a valid image file!"
+
+                bake_name = f'bake_{self.config.bake_type.lower()}'
+                ret[bake_name] = filepath
+                log.debug(f'Saved baked texture to disk for node "{str(self.current_node)}". Filename is {filepath}')
+
+            return ret

--- a/intermediary_representation.py
+++ b/intermediary_representation.py
@@ -41,6 +41,9 @@ class SceneRepresentation():
         self.shader_utils = shaders.ShaderUtils()
         self.material_baker = baking.MaterialBaker()
         self.evaluate = evaluate
+        # Save the render engine so we can restore it. For now we need Cycles for baking
+        self.previous_render_engine = str(self.scene.render.engine)
+        self.scene.render.engine = 'CYCLES'
 
     @property
     def camera(self):
@@ -76,6 +79,8 @@ class SceneRepresentation():
 
         for layer in self.layers:
             layer.teardown()
+
+        self.scene.render.engine = self.previous_render_engine # Restore to what we had before
 
     def _doCustomParams(self, custom_params, graph):
         for scene_object_name, params in custom_params.items():

--- a/intermediary_representation.py
+++ b/intermediary_representation.py
@@ -924,7 +924,7 @@ class ViewLayerNode(Node):
         for child_collection in self.view_layer.layer_collection.children:
             # A view layer might have children collections
             if not child_collection.exclude:
-                node = LayerCollectionNode(self.scene_graph, child_collection)
+                node = LayerCollectionNode(self.scene_graph, child_collection, parent=self)
                 self.children.append(node)
 
         # A view layer might have objects of its own
@@ -933,6 +933,9 @@ class ViewLayerNode(Node):
             graph.add_node(o)
 
         self.children.extend(graph.root.children)
+        for node in graph.root.children:
+            # Set up parenting
+            node.parent = self
 
     def evaluate(self):
         """Evaluates the ViewLayer and its hierarchy, applying modifiers and deformations"""
@@ -957,7 +960,7 @@ class ViewLayerNode(Node):
 class LayerCollectionNode(Node):
     """A node that represents a wrapper over Blender Collections"""
 
-    def __init__(self, scene_graph: SceneGraph, layer_collection: bpy.types.LayerCollection):
+    def __init__(self, scene_graph: SceneGraph, layer_collection: bpy.types.LayerCollection, parent: Node = None):
 
         super().__init__(name=f'{layer_collection.name}')
         self.scene_graph = scene_graph
@@ -965,6 +968,9 @@ class LayerCollectionNode(Node):
         self.collection = self.layer_collection.collection
         self.exclude = self.layer_collection.exclude
         self.is_visible = self.layer_collection.is_visible
+
+        if parent:
+            self.parent = parent
 
         for child_layer_collection in self.layer_collection.children:
             # A collection might have nested collections
@@ -977,3 +983,6 @@ class LayerCollectionNode(Node):
             graph.add_node(o)
 
         self.children.extend(graph.root.children)
+        for node in graph.root.children:
+            # Set up parenting
+            node.parent = self

--- a/intermediary_representation.py
+++ b/intermediary_representation.py
@@ -74,6 +74,9 @@ class SceneRepresentation():
     def teardown(self):
         self.graph.teardown()
 
+        for layer in self.layers:
+            layer.teardown()
+
     def _doCustomParams(self, custom_params, graph):
         for scene_object_name, params in custom_params.items():
             blender_object = self.scene.objects[scene_object_name]
@@ -564,7 +567,10 @@ class MeshNode(Node):
             self.remove_material_node(node)
 
         for image in self.created_images:
+            removed_name = image.name
             bpy.data.images.remove(image)
+            assert removed_name not in bpy.data.images
+            self.created_images.remove(image)
 
     def malformed(self):
         faces = self.get_faces()

--- a/intermediary_representation.py
+++ b/intermediary_representation.py
@@ -402,7 +402,6 @@ class SceneGraph():
 
         if o.type == 'MESH':
             node = MeshNode(o)
-
             if node.malformed():
                 log.debug(f'Malformed mesh with no faces: {str(node)}. '
                           + 'Adding placeholder.')
@@ -411,10 +410,10 @@ class SceneGraph():
                             name='Placeholder node for malformed '
                                  +f'mesh with no faces: {str(old_node)}')
                 old_node.teardown()
-
-            self.shader_utils.do_node(node)
-            assert node.vertex_shader
-            assert node.fragment_shader
+            else:
+                self.shader_utils.do_node(node)
+                assert node.vertex_shader
+                assert node.fragment_shader
 
         elif o.type == 'CAMERA':
             if o.data.type == 'PERSP':

--- a/utils.py
+++ b/utils.py
@@ -8,7 +8,10 @@
 #  -------------------------------------------------------------------------
 
 import os
+import bpy
+from contextlib import contextmanager
 from . import debug_utils
+from . import baking
 log = debug_utils.get_debug_logger()
 
 def get_addon_path():
@@ -16,8 +19,40 @@ def get_addon_path():
     directory = os.path.dirname(script_file)
     return directory
 
+@contextmanager
+def this_object_selected(a_object, make_active:bool=False, view_layer=None):
+    """A helper for selecting only this object for operations and then
+    restoring the selection state"""
+    selection_status = {}
+    # https://docs.blender.org/api/blender2.8/bpy.types.Depsgraph.html
+    # Selection depends on a context and is only valid for original objects. This means we need
+    # to request the original object from the known evaluated one.
+    a_object = a_object.original
+    for object_ in bpy.data.objects:
+        selection_status[object_.name_full] = object_.select_get()
+
+    bpy.ops.object.select_all(action='DESELECT')
+    a_object.select_set(True)
+
+    if make_active and view_layer:
+        view_layer.objects.active = a_object
+        selection_status['previously_active_view_layer'] = bpy.context.window.view_layer
+        bpy.context.window.view_layer = view_layer
+
+    yield a_object
+
+    for object_ in bpy.data.objects:
+        was_selected = selection_status[object_.name_full]
+        object_.select_set(was_selected)
+
+        if make_active and view_layer:
+            view_layer.objects.active = None
+            bpy.context.window.view_layer = selection_status['previously_active_view_layer']
+
+
 class CustomParameters():
     """Extra parameters we might set that are not a part of the Blender scene itself"""
     def __init__(self):
         self.shader_dir = ''
         self.render_technique = ''
+        self.material_bake = baking.MaterialBakeConfig()


### PR DESCRIPTION
This exporter currently does not support materials at all, so all meshes are rendered as white pixels by default.

The simplest approach for materials is baking them, since baking is supported natively by Blender. Cycles baking is explained at length [here](https://blender.stackexchange.com/questions/13508/how-do-i-bake-a-texture-using-cycles-bake) and [here](https://www.youtube.com/watch?v=sB09T--_ZvU). 

Upsides:
a) natively supported (bpy.ops.object.bake)
b) easy to implement for the exporter
c) the same strategy is used in other problem domains (e.g. game development)

Downsides:
a) since lights are frozen in place, the technique is subpar for scenes with a lot of moving objects.
b) it takes a while to bake even in low resolutions

This patch: 
a) switches the render engine to Cycles, reverting it after
b) creates an image node to receive the baked data, removing it after to avoid clutter
c) UV unwraps objects using the 'smart project' algorithm if needed, since only unwrapped objects can be baked. The extra UV layers are also removed after baking.
d) bakes MeshNodes to PNG files on disk

Still pending:
a) hook the baked data (PNG) to RAMSES
b) add tests